### PR TITLE
Revert: "HACK: loader/wine.inf.in: disable wine-mono"

### DIFF
--- a/loader/wine.inf.in
+++ b/loader/wine.inf.in
@@ -2074,7 +2074,7 @@ HKLM,%CurrentVersion%\Telephony\Country List\998,"SameAreaRule",,"G"
 11,,cryptnet.dll,1
 11,,devenum.dll,1
 11,,mp3dmod.dll,1
-;(cw)11,,mscoree.dll,1
+11,,mscoree.dll,1
 11,,mshtml.dll,1
 11,,msisip.dll,1
 11,,qcap.dll,1


### PR DESCRIPTION
Re-enables standard wine-mono installation handling.

Cherry picked from WineskinCX-22.0.1-1