### PR TITLE
win32u/imm: Preserve result_str when multiple IME updates occur in a single keystroke

### DIFF
--- a/dlls/win32u/imm.c
+++ b/dlls/win32u/imm.c
@@ -467,6 +467,26 @@ static void post_ime_update( HWND hwnd, UINT cursor_pos, WCHAR *comp_str, WCHAR 
     else
     {
         update->scan = data->ime_process_scan;
+
+        // If this update doesn't have a vkey, but the previous one does, merge them together so that the comp/result strings are not lost.
+        if (data->update && !update->result_str && data->update->result_str)
+        {
+            UINT prev_result_len = wcslen( data->update->result_str ) + 1;
+            struct ime_update *merged;
+
+            if ((merged = malloc( offsetof(struct ime_update, buffer[comp_len + prev_result_len]) )))
+            {
+                merged->vkey = update->vkey;
+                merged->scan = update->scan;
+                merged->cursor_pos = update->cursor_pos;
+                merged->comp_str = comp_len ? memcpy( merged->buffer, comp_str, comp_len * sizeof(WCHAR) ) : NULL;
+                merged->result_str = memcpy( merged->buffer + comp_len, data->update->result_str,
+                                             prev_result_len * sizeof(WCHAR) );
+                free( update );
+                update = merged;
+            }
+        }
+
         free( data->update );
         data->update = update;
     }


### PR DESCRIPTION
## Problem

Korean (한글) IME input is completely broken. No committed characters are ever delivered to applications via `GCS_RESULTSTR`.

## Root cause

Korean IME on macOS fires two `NSTextInputClient` callbacks in a single keystroke — `insertText:` (commit previous character) followed by `setMarkedText:` (begin new composition). For example, when typing `다` + `ㄹ`:

1. `insertText:@"다"` → `post_ime_update(comp=NULL, result="다")`
2. `setMarkedText:@"ㄹ"` → `post_ime_update(comp="ㄹ", result=NULL)`

In `post_ime_update()`, path B (`ImeProcessKey` context) stores updates in `data->update`, a single pointer. The second call `free()`s the first, discarding `result_str="다"`. The application never receives `WM_IME_COMPOSITION` with `GCS_RESULTSTR`.

Japanese and Chinese IMEs are unaffected because they commit and compose on separate keystrokes, so only one update occurs per `ImeProcessKey` call.

## Fix

When the second update arrives with no `result_str` but the existing `data->update` has one, merge the previous `result_str` into the new update before freeing.

## Testing

Verified with a minimal Win32 IME event logger:
- Before: only `GCS_COMPSTR` received, `GCS_RESULTSTR` absent
- After: both `GCS_COMPSTR` and `GCS_RESULTSTR` correctly delivered

Confirmed Korean input working in FFXIV in-game chat on macOS (Apple Silicon, XIV on Mac).