### PR TITLE
wineboot: retry driver installation for root PnP devices left in a half-installed state

### DIFF
--- a/programs/wineboot/wineboot.c
+++ b/programs/wineboot/wineboot.c
@@ -1547,8 +1547,24 @@ static void install_root_pnp_devices(void)
         if (!SetupDiCreateDeviceInfoA( set, root_devices[i].name, &GUID_NULL, NULL, NULL, 0, &device))
         {
             if (GetLastError() != ERROR_DEVINST_ALREADY_EXISTS)
+            {
                 WINE_ERR("Failed to create device %s, error %#lx.\n", debugstr_a(root_devices[i].name), GetLastError());
-            continue;
+                continue;
+            }
+
+            /* The device node was already created by a previous run, but that
+             * does not mean the driver was ever successfully installed for it
+             * -- e.g. an earlier UpdateDriverForPlugAndPlayDevices() call may
+             * have failed part-way through and left it in that state
+             * permanently, since we would always take this branch and skip
+             * reinstallation on every subsequent boot. Open the existing
+             * device info instead of skipping the rest of the installation,
+             * so a genuinely incomplete install gets retried. */
+            if (!SetupDiOpenDeviceInfoA(set, root_devices[i].name, NULL, 0, &device))
+            {
+                WINE_ERR("Failed to open existing device %s, error %#lx.\n", debugstr_a(root_devices[i].name), GetLastError());
+                continue;
+            }
         }
 
         if (!SetupDiSetDeviceRegistryPropertyA(set, &device, SPDRP_HARDWAREID,


### PR DESCRIPTION
`install_root_pnp_devices()` creates device nodes for the three root
pseudo-bus devices (winebth, winebus, wineusb) and then installs a driver
for each one. If `SetupDiCreateDeviceInfoA()` fails with
`ERROR_DEVINST_ALREADY_EXISTS`, the code currently skips the rest of the
install for that device entirely — including `SetupDiCallClassInstaller`
and `UpdateDriverForPlugAndPlayDevicesA`.

The problem is that "the device node already exists" and "the driver was
successfully installed for it" aren't the same thing. If a device node
gets created on one run but a later step in that same sequence fails or
gets interrupted, the device node persists in the registry with no driver
ever bound to it. Since `install_root_pnp_devices()` only runs once per
`wine.inf` version change, that half-installed state becomes permanent —
every future boot takes the `ERROR_DEVINST_ALREADY_EXISTS` branch and
skips reinstallation again, with no error logged anywhere pointing at the
actual problem.

We hit this in the wild: a wineprefix had a bare `Enum\ROOT\WINE\WINEBUS`
device node but no `Services\winebus` key at all, meaning no game
controller was ever detected, on a completely unmodified, working
`winebus.sys`/`winebus.so`. Manually deleting the stale device nodes and
re-running `wineboot --update` installed the driver correctly and
immediately, confirming the driver itself was never at fault.

This patch opens the existing device via `SetupDiOpenDeviceInfoA()` when
`SetupDiCreateDeviceInfoA()` reports `ERROR_DEVINST_ALREADY_EXISTS`,
instead of skipping the rest of the install for it.
`SetupDiCreateDeviceInfoA()` doesn't populate the `SP_DEVINFO_DATA`
out-parameter on this failure path, so the existing `device` local can't
just be reused as-is.

Verified against three scenarios: a fresh install (no existing device
node), a device node stuck in the half-installed state described above
(self-heals correctly), and a device that's already fully installed
(re-running is a harmless no-op, no regressions). Also confirmed that once
this ships, existing broken installs self-heal automatically on the very
next normal app launch — no manual steps needed — since packaging always
stamps `wine.inf` with a fresh mtime, which is what triggers Wine's
update-detection on boot.
