### PR TITLE
Handle audio device changes and synchronize the default output

### DIFF
--- a/dlls/mmdevapi/devenum.c
+++ b/dlls/mmdevapi/devenum.c
@@ -1302,11 +1302,14 @@ static HRESULT WINAPI MMDevEnum_GetDefaultAudioEndpoint(IMMDeviceEnumerator *ifa
                     RegCloseKey(key);
                     return S_OK;
                 }
+                IMMDevice_Release(*device);
+                *device = NULL;
             }
 
             TRACE("Unable to find voice device %s\n", wine_dbgstr_w(def_id));
         }
 
+        size = sizeof(def_id);
         if((!drvs.native_notifications || flow != eRender) &&
                 RegQueryValueExW(key, reg_x_name, 0, NULL,
                     (BYTE*)def_id, &size) == ERROR_SUCCESS){

--- a/dlls/mmdevapi/devenum.c
+++ b/dlls/mmdevapi/devenum.c
@@ -47,6 +47,16 @@ DEFINE_GUID(GUID_NULL,0,0,0,0,0,0,0,0,0,0,0);
 static HKEY key_render;
 static HKEY key_capture;
 
+static CRITICAL_SECTION devices_lock;
+static CRITICAL_SECTION_DEBUG devices_lock_debug =
+{
+    0, 0, &devices_lock,
+    { &devices_lock_debug.ProcessLocksList, &devices_lock_debug.ProcessLocksList },
+    0, 0, { (DWORD_PTR)(__FILE__ ": devices_lock") }
+};
+static CRITICAL_SECTION devices_lock = { &devices_lock_debug, -1, 0, 0, 0, 0 };
+
+
 typedef struct MMDevPropStoreImpl
 {
     IPropertyStore IPropertyStore_iface;
@@ -150,16 +160,20 @@ static void add_device_to_cache( const GUID *guid, const char *name, EDataFlow f
     dev->guid = *guid;
     dev->flow = flow;
     strcpy( dev->name, name );
+    EnterCriticalSection(&devices_lock);
     list_add_tail( &devices_cache, &dev->entry );
+    LeaveCriticalSection(&devices_lock);
 }
 
 static struct device *find_device_in_cache( const GUID *guid )
 {
-    struct device *dev;
+    struct device *dev, *found = NULL;
 
+    EnterCriticalSection(&devices_lock);
     LIST_FOR_EACH_ENTRY( dev, &devices_cache, struct device, entry )
-        if (IsEqualGUID( guid, &dev->guid )) return dev;
-    return NULL;
+        if (IsEqualGUID( guid, &dev->guid )) { found = dev; break; }
+    LeaveCriticalSection(&devices_lock);
+    return found;
 }
 
 BOOL get_device_name_from_guid( const GUID *guid, char **name, EDataFlow *flow )
@@ -445,7 +459,7 @@ static MMDevice *MMDevice_Create(const WCHAR *name, GUID *id, EDataFlow flow, DW
 {
     HKEY key, root;
     MMDevice *device, *cur = NULL;
-    WCHAR guidstr[39];
+    WCHAR guidstr[39], *copy;
 
     static const PROPERTYKEY deviceinterface_key = {
         {0x233164c8, 0x1b2c, 0x4c7d, {0xbc, 0x68, 0xb6, 0x71, 0x68, 0x7a, 0x25, 0x67}}, 1
@@ -454,6 +468,8 @@ static MMDevice *MMDevice_Create(const WCHAR *name, GUID *id, EDataFlow flow, DW
     static const PROPERTYKEY devicepath_key = {
         {0xb3f8fa53, 0x0004, 0x438e, {0x90, 0x03, 0x51, 0xa4, 0x6e, 0x13, 0x9b, 0xfc}}, 2
     };
+
+    if (!(copy = wcsdup(name))) return NULL;
 
     LIST_FOR_EACH_ENTRY(device, &device_list, MMDevice, entry)
     {
@@ -466,18 +482,17 @@ static MMDevice *MMDevice_Create(const WCHAR *name, GUID *id, EDataFlow flow, DW
     if(!cur){
         /* No device found, allocate new one */
         cur = calloc(1, sizeof(*cur));
-        if (!cur)
-            return NULL;
+        if (!cur) { free(copy); return NULL; }
 
         cur->IMMDevice_iface.lpVtbl = &MMDeviceVtbl;
         cur->IMMEndpoint_iface.lpVtbl = &MMEndpointVtbl;
 
         list_add_tail(&device_list, &cur->entry);
-    }else if(cur->ref > 0)
+    }else if(cur->ref > 0 && !drvs.native_notifications)
         WARN("Modifying an MMDevice with postitive reference count!\n");
 
     free(cur->drv_id);
-    cur->drv_id = wcsdup(name);
+    cur->drv_id = copy;
 
     cur->flow = flow;
     cur->state = state;
@@ -566,7 +581,7 @@ static MMDevice *MMDevice_Create(const WCHAR *name, GUID *id, EDataFlow flow, DW
 HRESULT load_devices_from_reg(void)
 {
     DWORD i = 0;
-    HKEY root, cur;
+    HKEY root = NULL, cur;
     LONG ret;
     DWORD curflow;
 
@@ -577,7 +592,7 @@ HRESULT load_devices_from_reg(void)
         ret = RegCreateKeyExW(root, L"Capture", 0, NULL, 0, KEY_READ|KEY_WRITE|KEY_WOW64_64KEY, NULL, &key_capture, NULL);
     if (ret == ERROR_SUCCESS)
         ret = RegCreateKeyExW(root, L"Render", 0, NULL, 0, KEY_READ|KEY_WRITE|KEY_WOW64_64KEY, NULL, &key_render, NULL);
-    RegCloseKey(root);
+    if (root) RegCloseKey(root);
     cur = key_capture;
     curflow = eCapture;
     if (ret != ERROR_SUCCESS)
@@ -653,39 +668,137 @@ static HRESULT set_format(MMDevice *dev)
     return S_OK;
 }
 
+static HRESULT query_driver_devices(EDataFlow flow, struct get_endpoint_ids_params *params)
+{
+    void *buffer;
+
+    params->flow = flow;
+    params->size = 1024;
+    params->endpoints = NULL;
+    do
+    {
+        if (!(buffer = realloc(params->endpoints, params->size))) return E_OUTOFMEMORY;
+        params->endpoints = buffer;
+        if (__wine_unix_call(drvs.module_unixlib, get_endpoint_ids, params)) return E_FAIL;
+    } while (params->result == HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER));
+    return params->result;
+}
+
+static HRESULT register_driver_devices(const struct get_endpoint_ids_params *params)
+{
+    UINT i;
+
+    for (i = 0; i < params->num; ++i)
+    {
+        GUID guid = GUID_NULL;
+        MMDevice *dev;
+        const WCHAR *name = (WCHAR *)((char *)params->endpoints + params->endpoints[i].name);
+        const char *dev_name = (char *)params->endpoints + params->endpoints[i].device;
+
+        get_device_guid(params->flow, dev_name, &guid);
+        if (IsEqualGUID(&guid, &GUID_NULL)) return E_FAIL;
+        dev = MMDevice_Create(name, &guid, params->flow, DEVICE_STATE_ACTIVE, params->default_idx == i);
+        if (!dev) return E_OUTOFMEMORY;
+        dev->present = TRUE;
+        set_format(dev);
+    }
+    return S_OK;
+}
+
 HRESULT load_driver_devices(EDataFlow flow)
 {
     struct get_endpoint_ids_params params;
-    UINT i;
+    HRESULT hr;
 
-    params.flow = flow;
-    params.size = 1024;
-    params.endpoints = NULL;
-    do {
-        free(params.endpoints);
-        params.endpoints = malloc(params.size);
-        __wine_unix_call(drvs.module_unixlib, get_endpoint_ids, &params);
+    hr = query_driver_devices(flow, &params);
+    if (SUCCEEDED(hr)) hr = register_driver_devices(&params);
+    free(params.endpoints);
+    return hr;
+}
+
+static HRESULT rescan_devices(void)
+{
+    struct get_endpoint_ids_params params[2] = {{0}};
+    MMDevice *dev, *old_play, *old_rec;
+    HRESULT hr;
+
+    if (FAILED(hr = query_driver_devices(eRender, &params[eRender])) ||
+        FAILED(hr = query_driver_devices(eCapture, &params[eCapture]))) goto done;
+
+    EnterCriticalSection(&devices_lock);
+    old_play = MMDevice_def_play;
+    old_rec = MMDevice_def_rec;
+    MMDevice_def_play = MMDevice_def_rec = NULL;
+    LIST_FOR_EACH_ENTRY(dev, &device_list, MMDevice, entry) dev->present = FALSE;
+    hr = register_driver_devices(&params[eRender]);
+    if (SUCCEEDED(hr)) hr = register_driver_devices(&params[eCapture]);
+    if (SUCCEEDED(hr))
+    {
+        /* Retain objects held by applications instead of freeing them during a rescan. */
+        LIST_FOR_EACH_ENTRY(dev, &device_list, MMDevice, entry)
+            if (!dev->present) dev->state = DEVICE_STATE_NOTPRESENT;
+    }
+    else
+    {
+        MMDevice_def_play = old_play;
+        MMDevice_def_rec = old_rec;
+    }
+    LeaveCriticalSection(&devices_lock);
+done:
+    free(params[eRender].endpoints);
+    free(params[eCapture].endpoints);
+    return hr;
+}
+
+static HRESULT sync_default_output(void)
+{
+    struct get_default_output_params params = {NULL, 256, E_FAIL};
+    struct device *cached;
+    MMDevice *dev;
+    char *buffer;
+    HRESULT hr;
+
+    do
+    {
+        if (!(buffer = realloc(params.device, params.size)))
+        {
+            free(params.device);
+            return E_OUTOFMEMORY;
+        }
+        params.device = buffer;
+        if (__wine_unix_call(drvs.module_unixlib, get_default_output, &params))
+            params.result = E_FAIL;
     } while (params.result == HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER));
 
-    if (FAILED(params.result))
-        goto end;
-
-    for (i = 0; i < params.num; i++) {
-        GUID guid;
-        MMDevice *dev;
-        const WCHAR *name = (WCHAR *)((char *)params.endpoints + params.endpoints[i].name);
-        const char *dev_name = (char *)params.endpoints + params.endpoints[i].device;
-
-        get_device_guid( flow, dev_name, &guid );
-
-        dev = MMDevice_Create(name, &guid, flow, DEVICE_STATE_ACTIVE, params.default_idx == i);
-        set_format(dev);
+    hr = params.result;
+    if (FAILED(hr)) goto done;
+    EnterCriticalSection(&devices_lock);
+    if (hr == S_FALSE)
+    {
+        MMDevice_def_play = NULL;
+        hr = S_OK;
     }
-
-end:
-    free(params.endpoints);
-
-    return params.result;
+    else
+    {
+        hr = E_NOTFOUND;
+        LIST_FOR_EACH_ENTRY(cached, &devices_cache, struct device, entry)
+        {
+            if (cached->flow != eRender || strcmp(cached->name, params.device)) continue;
+            LIST_FOR_EACH_ENTRY(dev, &device_list, MMDevice, entry)
+            {
+                if (dev->flow != eRender || dev->state != DEVICE_STATE_ACTIVE ||
+                    !IsEqualGUID(&dev->devguid, &cached->guid)) continue;
+                MMDevice_def_play = dev;
+                hr = S_OK;
+                break;
+            }
+            break;
+        }
+    }
+    LeaveCriticalSection(&devices_lock);
+done:
+    free(params.device);
+    return hr;
 }
 
 static void MMDevice_Destroy(MMDevice *This)
@@ -871,7 +984,9 @@ static HRESULT WINAPI MMDevice_GetState(IMMDevice *iface, DWORD *state)
 
     if (!state)
         return E_POINTER;
+    EnterCriticalSection(&devices_lock);
     *state = This->state;
+    LeaveCriticalSection(&devices_lock);
     return S_OK;
 }
 
@@ -946,6 +1061,7 @@ static HRESULT MMDevCol_Create(IMMDeviceCollection **ppv, EDataFlow flow, DWORD 
     This->devices_count = 0;
     *ppv = &This->IMMDeviceCollection_iface;
 
+    EnterCriticalSection(&devices_lock);
     LIST_FOR_EACH_ENTRY(cur, &device_list, MMDevice, entry)
     {
         if ((cur->flow == flow || flow == eAll) && (cur->state & state))
@@ -955,8 +1071,13 @@ static HRESULT MMDevCol_Create(IMMDeviceCollection **ppv, EDataFlow flow, DWORD 
     if (This->devices_count)
     {
         This->devices = malloc(This->devices_count * sizeof(IMMDevice *));
-        if (!This->devices_count)
+        if (!This->devices)
+        {
+            LeaveCriticalSection(&devices_lock);
+            free(This);
+            *ppv = NULL;
             return E_OUTOFMEMORY;
+        }
 
         LIST_FOR_EACH_ENTRY(cur, &device_list, MMDevice, entry)
         {
@@ -969,6 +1090,7 @@ static HRESULT MMDevCol_Create(IMMDeviceCollection **ppv, EDataFlow flow, DWORD 
         }
     }
 
+    LeaveCriticalSection(&devices_lock);
     return S_OK;
 }
 
@@ -1073,8 +1195,13 @@ void MMDevEnum_Free(void)
         MMDevice_Destroy(device);
     RegCloseKey(key_render);
     RegCloseKey(key_capture);
+    key_render = key_capture = NULL;
+    MMDevice_def_play = MMDevice_def_rec = NULL;
     LIST_FOR_EACH_ENTRY_SAFE(dev, dev_next, &devices_cache, struct device, entry)
-        free( dev );
+    {
+        list_remove(&dev->entry);
+        free(dev);
+    }
 }
 
 static HRESULT WINAPI MMDevEnum_QueryInterface(IMMDeviceEnumerator *iface, REFIID riid, void **ppv)
@@ -1180,7 +1307,8 @@ static HRESULT WINAPI MMDevEnum_GetDefaultAudioEndpoint(IMMDeviceEnumerator *ifa
             TRACE("Unable to find voice device %s\n", wine_dbgstr_w(def_id));
         }
 
-        if(RegQueryValueExW(key, reg_x_name, 0, NULL,
+        if((!drvs.native_notifications || flow != eRender) &&
+                RegQueryValueExW(key, reg_x_name, 0, NULL,
                     (BYTE*)def_id, &size) == ERROR_SUCCESS){
             hr = IMMDeviceEnumerator_GetDevice(iface, def_id, device);
             if(SUCCEEDED(hr)){
@@ -1197,15 +1325,15 @@ static HRESULT WINAPI MMDevEnum_GetDefaultAudioEndpoint(IMMDeviceEnumerator *ifa
         RegCloseKey(key);
     }
 
+    if (*device) IMMDevice_Release(*device);
+    EnterCriticalSection(&devices_lock);
     if (flow == eRender)
-        *device = &MMDevice_def_play->IMMDevice_iface;
+        *device = MMDevice_def_play ? &MMDevice_def_play->IMMDevice_iface : NULL;
     else
-        *device = &MMDevice_def_rec->IMMDevice_iface;
-
-    if (!*device)
-        return E_NOTFOUND;
-    IMMDevice_AddRef(*device);
-    return S_OK;
+        *device = MMDevice_def_rec ? &MMDevice_def_rec->IMMDevice_iface : NULL;
+    if (*device) IMMDevice_AddRef(*device);
+    LeaveCriticalSection(&devices_lock);
+    return *device ? S_OK : E_NOTFOUND;
 }
 
 static HRESULT WINAPI MMDevEnum_GetDevice(IMMDeviceEnumerator *iface, const WCHAR *name, IMMDevice **device)
@@ -1219,6 +1347,8 @@ static HRESULT WINAPI MMDevEnum_GetDevice(IMMDeviceEnumerator *iface, const WCHA
     if(!name || !device)
         return E_POINTER;
 
+    *device = NULL;
+    EnterCriticalSection(&devices_lock);
     LIST_FOR_EACH_ENTRY(impl, &device_list, MMDevice, entry)
     {
         HRESULT hr;
@@ -1236,10 +1366,12 @@ static HRESULT WINAPI MMDevEnum_GetDevice(IMMDeviceEnumerator *iface, const WCHA
             CoTaskMemFree(str);
             IMMDevice_AddRef(dev);
             *device = dev;
+            LeaveCriticalSection(&devices_lock);
             return S_OK;
         }
         CoTaskMemFree(str);
     }
+    LeaveCriticalSection(&devices_lock);
     TRACE("Could not find device %s\n", debugstr_w(name));
     return E_INVALIDARG;
 }
@@ -1282,7 +1414,14 @@ static BOOL notify_if_changed(EDataFlow flow, ERole role, HKEY key,
     HRESULT hr;
 
     size = sizeof(new_val);
-    if(RegQueryValueExW(key, val_name, 0, NULL,
+    if (!key)
+    {
+        id = NULL;
+        if (def_dev && FAILED(IMMDevice_GetId(def_dev, &id))) return FALSE;
+        lstrcpynW(new_val, id ? id : L"", ARRAY_SIZE(new_val));
+        CoTaskMemFree(id);
+    }
+    else if(RegQueryValueExW(key, val_name, 0, NULL,
                 (BYTE*)new_val, &size) != ERROR_SUCCESS){
         if(old_val[0] != 0){
             /* set by user -> system default */
@@ -1337,12 +1476,27 @@ static BOOL notify_if_changed(EDataFlow flow, ERole role, HKEY key,
 
 static DWORD WINAPI notif_thread_proc(void *user)
 {
-    HKEY key;
+    HKEY key = NULL;
     WCHAR reg_key[256];
     WCHAR out_name[64], vout_name[64], in_name[64], vin_name[64];
     DWORD size;
+    struct device_notifications_wait_params wait = {INFINITE};
+    UINT pending = 0;
+    HRESULT hr;
 
     SetThreadDescription(GetCurrentThread(), L"wine_mmdevapi_notification");
+
+    if (drvs.native_notifications)
+    {
+        WCHAR *id = NULL;
+        out_name[0] = 0;
+        if (MMDevice_def_play && SUCCEEDED(IMMDevice_GetId(&MMDevice_def_play->IMMDevice_iface, &id)))
+        {
+            lstrcpynW(out_name, id, ARRAY_SIZE(out_name));
+            CoTaskMemFree(id);
+        }
+        goto monitor;
+    }
 
     lstrcpyW(reg_key, drv_keyW);
     lstrcatW(reg_key, L"\\");
@@ -1370,8 +1524,30 @@ static DWORD WINAPI notif_thread_proc(void *user)
     if(RegQueryValueExW(key, L"DefaultVoiceInput", 0, NULL, (BYTE*)vin_name, &size) != ERROR_SUCCESS)
         vin_name[0] = 0;
 
+monitor:
     while(1){
-        if(RegNotifyChangeKeyValue(key, FALSE, REG_NOTIFY_CHANGE_LAST_SET,
+        if (drvs.native_notifications)
+        {
+            if (__wine_unix_call(drvs.module_unixlib, device_notifications_wait, &wait))
+            { Sleep(100); continue; }
+            if (wait.result == E_ABORT) break;
+            if (FAILED(wait.result)) { Sleep(100); continue; }
+            pending |= wait.changes;
+            if (pending & DEVICE_CHANGE_LIST)
+            {
+                if (FAILED(rescan_devices())) { wait.timeout = 100; continue; }
+                pending = (pending & ~DEVICE_CHANGE_LIST) | DEVICE_CHANGE_DEFAULT_OUTPUT;
+            }
+            if (pending & DEVICE_CHANGE_DEFAULT_OUTPUT)
+            {
+                hr = sync_default_output();
+                if (hr == E_NOTFOUND) pending |= DEVICE_CHANGE_LIST;
+                if (SUCCEEDED(hr)) pending &= ~DEVICE_CHANGE_DEFAULT_OUTPUT;
+            }
+            wait.timeout = pending ? 100 : INFINITE;
+            if (wait.timeout != INFINITE) continue;
+        }
+        else if(RegNotifyChangeKeyValue(key, FALSE, REG_NOTIFY_CHANGE_LAST_SET,
                     NULL, FALSE) != ERROR_SUCCESS){
             ERR("RegNotifyChangeKeyValue failed: %lu\n", GetLastError());
             RegCloseKey(key);
@@ -1381,23 +1557,61 @@ static DWORD WINAPI notif_thread_proc(void *user)
 
         EnterCriticalSection(&g_notif_lock);
 
-        notify_if_changed(eRender, eConsole, key, L"DefaultOutput",
-                out_name, &MMDevice_def_play->IMMDevice_iface);
-        notify_if_changed(eRender, eCommunications, key, L"DefaultVoiceOutput",
-                vout_name, &MMDevice_def_play->IMMDevice_iface);
-        notify_if_changed(eCapture, eConsole, key, L"DefaultInput",
-                in_name, &MMDevice_def_rec->IMMDevice_iface);
-        notify_if_changed(eCapture, eCommunications, key, L"DefaultVoiceInput",
-                vin_name, &MMDevice_def_rec->IMMDevice_iface);
+        if (drvs.native_notifications)
+            notify_if_changed(eRender, eConsole, NULL, NULL, out_name,
+                    MMDevice_def_play ? &MMDevice_def_play->IMMDevice_iface : NULL);
+        else
+        {
+            notify_if_changed(eRender, eConsole, key, L"DefaultOutput",
+                    out_name, MMDevice_def_play ? &MMDevice_def_play->IMMDevice_iface : NULL);
+            notify_if_changed(eRender, eCommunications, key, L"DefaultVoiceOutput",
+                    vout_name, MMDevice_def_play ? &MMDevice_def_play->IMMDevice_iface : NULL);
+            notify_if_changed(eCapture, eConsole, key, L"DefaultInput",
+                    in_name, MMDevice_def_rec ? &MMDevice_def_rec->IMMDevice_iface : NULL);
+            notify_if_changed(eCapture, eCommunications, key, L"DefaultVoiceInput",
+                    vin_name, MMDevice_def_rec ? &MMDevice_def_rec->IMMDevice_iface : NULL);
+
+        }
 
         LeaveCriticalSection(&g_notif_lock);
     }
 
-    RegCloseKey(key);
+    if (key) RegCloseKey(key);
 
     g_notif_thread = NULL;
 
     return 0;
+}
+
+HRESULT start_device_notifications(void)
+{
+    struct device_notifications_start_params params = {E_NOTIMPL};
+    HMODULE module;
+    HANDLE thread;
+    HRESULT hr;
+
+    if (__wine_unix_call(drvs.module_unixlib, device_notifications_start, &params)) return E_FAIL;
+    if (FAILED(params.result)) return params.result;
+    drvs.native_notifications = TRUE;
+    if (FAILED(hr = load_devices_from_reg()) || FAILED(hr = rescan_devices())) goto failed;
+    if (!(thread = g_notif_thread = CreateThread(NULL, 0, notif_thread_proc, NULL, 0, NULL)))
+    { hr = HRESULT_FROM_WIN32(GetLastError()); goto failed; }
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
+                           (const WCHAR *)start_device_notifications, &module))
+    {
+        hr = HRESULT_FROM_WIN32(GetLastError());
+        wine_unix_call(device_notifications_stop, NULL);
+        WaitForSingleObject(thread, INFINITE);
+        CloseHandle(thread);
+        g_notif_thread = NULL;
+        goto failed;
+    }
+    return S_OK;
+failed:
+    wine_unix_call(device_notifications_stop, NULL);
+    MMDevEnum_Free();
+    drvs.native_notifications = FALSE;
+    return hr;
 }
 
 static HRESULT WINAPI MMDevEnum_RegisterEndpointNotificationCallback(IMMDeviceEnumerator *iface, IMMNotificationClient *client)
@@ -1420,7 +1634,7 @@ static HRESULT WINAPI MMDevEnum_RegisterEndpointNotificationCallback(IMMDeviceEn
 
     list_add_tail(&g_notif_clients, &wrapper->entry);
 
-    if(!g_notif_thread){
+    if(!g_notif_thread && !drvs.native_notifications){
         g_notif_thread = CreateThread(NULL, 0, notif_thread_proc, NULL, 0, NULL);
         if(!g_notif_thread)
             ERR("CreateThread failed: %lu\n", GetLastError());

--- a/dlls/mmdevapi/main.c
+++ b/dlls/mmdevapi/main.c
@@ -50,6 +50,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(mmdevapi);
 
 DriverFuncs drvs;
 static DriverFuncs midi_driver;
+static HRESULT driver_init_hr = S_OK;
 
 #define MIDI_CALL(code,args)  __wine_unix_call( midi_driver.module_unixlib, code, args )
 
@@ -75,6 +76,8 @@ static BOOL load_driver(const WCHAR *name, DriverFuncs *driver)
     NTSTATUS status;
     WCHAR driver_module[264], path[MAX_PATH];
     struct test_connect_params params;
+
+    driver->native_notifications = FALSE;
 
     lstrcpyW(driver_module, L"wine");
     lstrcatW(driver_module, name);
@@ -186,9 +189,28 @@ static BOOL WINAPI init_driver(INIT_ONCE *once, void *param, void **context)
         }
         else midi_driver = drvs;
 
-        load_devices_from_reg();
-        load_driver_devices(eRender);
-        load_driver_devices(eCapture);
+        driver_init_hr = start_device_notifications();
+        if (driver_init_hr == E_NOTIMPL)
+        {
+            driver_init_hr = S_OK;
+            load_devices_from_reg();
+            load_driver_devices(eRender);
+            load_driver_devices(eCapture);
+        }
+        else if (FAILED(driver_init_hr))
+        {
+            ERR("Failed to initialize audio device notifications: %08lx\n", driver_init_hr);
+            if (midi_driver.module_unixlib && midi_driver.module != drvs.module)
+            {
+                MIDI_CALL( process_detach, NULL );
+                FreeLibrary( midi_driver.module );
+            }
+            wine_unix_call( process_detach, NULL );
+            FreeLibrary( drvs.module );
+            midi_driver = (DriverFuncs){0};
+            drvs = (DriverFuncs){0};
+            return TRUE;
+        }
     }
 
     if (drvs.module == 0)
@@ -209,6 +231,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
             DisableThreadLibraryCalls(hinstDLL);
             break;
         case DLL_PROCESS_DETACH:
+            if (drvs.native_notifications) break;
             if (drvs.module_unixlib)
             {
                 wine_unix_call( process_detach, NULL );
@@ -319,6 +342,7 @@ HRESULT WINAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID *ppv)
     TRACE("(%s, %s, %p)\n", debugstr_guid(rclsid), debugstr_guid(riid), ppv);
 
     InitOnceExecuteOnce(&init_once, init_driver, NULL, NULL);
+    if (FAILED(driver_init_hr)) return driver_init_hr;
 
     if (ppv == NULL) {
         WARN("invalid parameter\n");
@@ -378,6 +402,7 @@ static DWORD WINAPI notify_thread( void *p )
 LRESULT WINAPI DriverProc( DWORD_PTR id, HANDLE driver, UINT msg, LPARAM param1, LPARAM param2 )
 {
     InitOnceExecuteOnce( &init_once, init_driver, NULL, NULL );
+    if (FAILED(driver_init_hr)) return 0;
     if (!midi_driver.module_unixlib) return 0;
 
     switch(msg)

--- a/dlls/mmdevapi/mmdevapi_private.h
+++ b/dlls/mmdevapi/mmdevapi_private.h
@@ -97,6 +97,7 @@ typedef struct _DriverFuncs {
      * priority value reflecting the likelihood that they are actually
      * valid. See enum _DriverPriority. */
     int priority;
+    BOOL native_notifications;
 } DriverFuncs;
 
 extern DriverFuncs drvs;
@@ -108,6 +109,7 @@ typedef struct MMDevice {
 
     EDataFlow flow;
     DWORD state;
+    BOOL present;
     GUID devguid;
     WCHAR *drv_id;
 
@@ -128,6 +130,7 @@ extern HRESULT SpatialAudioClient_Create(IMMDevice *device, ISpatialAudioClient 
 extern BOOL get_device_name_from_guid( const GUID *guid, char **name, EDataFlow *flow );
 extern HRESULT load_devices_from_reg(void);
 extern HRESULT load_driver_devices(EDataFlow flow);
+extern HRESULT start_device_notifications(void);
 
 extern void main_loop_stop(void);
 

--- a/dlls/mmdevapi/unixlib.h
+++ b/dlls/mmdevapi/unixlib.h
@@ -311,6 +311,28 @@ struct aux_message_params
     UINT *err;
 };
 
+struct device_notifications_start_params
+{
+    HRESULT result;
+};
+
+struct device_notifications_wait_params
+{
+    UINT timeout;
+    UINT changes;
+    HRESULT result;
+};
+
+struct get_default_output_params
+{
+    char *device;
+    UINT size;
+    HRESULT result;
+};
+
+#define DEVICE_CHANGE_LIST 1
+#define DEVICE_CHANGE_DEFAULT_OUTPUT 2
+
 enum unix_funcs
 {
     process_attach,
@@ -350,5 +372,9 @@ enum unix_funcs
     midi_in_message,
     midi_notify_wait,
     aux_message,
+    device_notifications_start,
+    device_notifications_wait,
+    device_notifications_stop,
+    get_default_output,
     funcs_count
 };

--- a/dlls/winealsa.drv/alsa.c
+++ b/dlls/winealsa.drv/alsa.c
@@ -2454,6 +2454,10 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
     alsa_midi_in_message,
     alsa_midi_notify_wait,
     alsa_not_implemented,
+    alsa_not_implemented,
+    alsa_not_implemented,
+    alsa_not_implemented,
+    alsa_not_implemented,
 };
 
 C_ASSERT(ARRAYSIZE(__wine_unix_call_funcs) == funcs_count);
@@ -2910,6 +2914,10 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
     alsa_wow64_midi_out_message,
     alsa_wow64_midi_in_message,
     alsa_wow64_midi_notify_wait,
+    alsa_not_implemented,
+    alsa_not_implemented,
+    alsa_not_implemented,
+    alsa_not_implemented,
     alsa_not_implemented,
 };
 

--- a/dlls/winecoreaudio.drv/coreaudio.c
+++ b/dlls/winecoreaudio.drv/coreaudio.c
@@ -41,6 +41,7 @@
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <fenv.h>
+#include <pthread.h>
 #include <unistd.h>
 
 #include <CoreAudio/CoreAudio.h>
@@ -108,6 +109,230 @@ static const REFERENCE_TIME def_period = 100000;
 static const REFERENCE_TIME min_period = 50000;
 
 static ULONG_PTR zero_bits = 0;
+
+static pthread_mutex_t device_notifications_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t device_notifications_cond = PTHREAD_COND_INITIALIZER;
+static BOOL device_notifications_running;
+static UINT device_notifications_pending;
+static unsigned int device_notifications_registered;
+
+static const AudioObjectPropertyAddress device_notifications_addresses[] =
+{
+    { kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain },
+    { kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain },
+};
+
+static HRESULT osstatus_to_hresult(OSStatus sc);
+
+static OSStatus device_notifications_callback(AudioObjectID object_id, UInt32 number_addresses,
+        const AudioObjectPropertyAddress *addresses, void *client_data)
+{
+    UInt32 i;
+
+    pthread_mutex_lock(&device_notifications_lock);
+    if (device_notifications_running)
+    {
+        for (i = 0; i < number_addresses; ++i)
+        {
+            if (addresses[i].mSelector == kAudioHardwarePropertyDevices)
+                device_notifications_pending |= DEVICE_CHANGE_LIST;
+            else if (addresses[i].mSelector == kAudioHardwarePropertyDefaultOutputDevice)
+                device_notifications_pending |= DEVICE_CHANGE_DEFAULT_OUTPUT;
+        }
+        if (device_notifications_pending) pthread_cond_signal(&device_notifications_cond);
+    }
+    pthread_mutex_unlock(&device_notifications_lock);
+    return noErr;
+}
+
+static void device_notifications_remove_listeners(void)
+{
+    while (device_notifications_registered)
+    {
+        --device_notifications_registered;
+        AudioObjectRemovePropertyListener(kAudioObjectSystemObject,
+                &device_notifications_addresses[device_notifications_registered],
+                device_notifications_callback, NULL);
+    }
+}
+
+static NTSTATUS unix_device_notifications_start(void *args)
+{
+    struct device_notifications_start_params *params = args;
+    OSStatus status;
+
+    pthread_mutex_lock(&device_notifications_lock);
+    if (device_notifications_running)
+    {
+        params->result = S_OK;
+        pthread_mutex_unlock(&device_notifications_lock);
+        return STATUS_SUCCESS;
+    }
+    device_notifications_running = TRUE;
+    device_notifications_pending = 0;
+    pthread_mutex_unlock(&device_notifications_lock);
+
+    /* Do not let CoreAudio dispatch callbacks through an application run loop. */
+    status = AudioObjectSetPropertyData(kAudioObjectSystemObject,
+            &(AudioObjectPropertyAddress){ kAudioHardwarePropertyRunLoop,
+                kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain },
+            0, NULL, sizeof(CFRunLoopRef), &(CFRunLoopRef){ NULL });
+    if (status != noErr) goto failed;
+
+    for (device_notifications_registered = 0;
+            device_notifications_registered < ARRAY_SIZE(device_notifications_addresses);
+            ++device_notifications_registered)
+    {
+        status = AudioObjectAddPropertyListener(kAudioObjectSystemObject,
+                &device_notifications_addresses[device_notifications_registered],
+                device_notifications_callback, NULL);
+        if (status != noErr) goto failed;
+    }
+
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+
+failed:
+    device_notifications_remove_listeners();
+    pthread_mutex_lock(&device_notifications_lock);
+    device_notifications_running = FALSE;
+    pthread_cond_broadcast(&device_notifications_cond);
+    pthread_mutex_unlock(&device_notifications_lock);
+    params->result = osstatus_to_hresult(status);
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS unix_device_notifications_wait(void *args)
+{
+    struct device_notifications_wait_params *params = args;
+    int status = 0;
+
+    pthread_mutex_lock(&device_notifications_lock);
+    if (!device_notifications_running)
+    {
+        params->changes = 0;
+        pthread_mutex_unlock(&device_notifications_lock);
+        params->result = E_ABORT;
+        return STATUS_SUCCESS;
+    }
+    while (!device_notifications_pending && device_notifications_running)
+    {
+        if (params->timeout == INFINITE)
+            status = pthread_cond_wait(&device_notifications_cond, &device_notifications_lock);
+        else
+        {
+            struct timespec timeout;
+            timeout.tv_sec = params->timeout / 1000;
+            timeout.tv_nsec = (params->timeout % 1000) * 1000000;
+            status = pthread_cond_timedwait_relative_np(&device_notifications_cond,
+                    &device_notifications_lock, &timeout);
+        }
+        if (status == ETIMEDOUT) break;
+        if (status != 0)
+        {
+            pthread_mutex_unlock(&device_notifications_lock);
+            params->changes = 0;
+            params->result = E_FAIL;
+            return STATUS_SUCCESS;
+        }
+    }
+
+    if (!device_notifications_running)
+    {
+        params->changes = 0;
+        params->result = E_ABORT;
+    }
+    else if (device_notifications_pending)
+    {
+        params->changes = device_notifications_pending;
+        device_notifications_pending = 0;
+        params->result = S_OK;
+    }
+    else
+    {
+        params->changes = 0;
+        params->result = S_FALSE;
+    }
+    pthread_mutex_unlock(&device_notifications_lock);
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS unix_device_notifications_stop(void *args)
+{
+    pthread_mutex_lock(&device_notifications_lock);
+    device_notifications_running = FALSE;
+    device_notifications_pending = 0;
+    pthread_cond_broadcast(&device_notifications_cond);
+    pthread_mutex_unlock(&device_notifications_lock);
+
+    device_notifications_remove_listeners();
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS unix_get_default_output(void *args)
+{
+    struct get_default_output_params *params = args;
+    AudioObjectPropertyAddress address =
+    {
+        kAudioHardwarePropertyDefaultOutputDevice,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain
+    };
+    AudioDeviceID device;
+    CFStringRef uid = NULL;
+    CFIndex length;
+    UInt32 size;
+    UINT capacity;
+    OSStatus status;
+
+    size = sizeof(device);
+    status = AudioObjectGetPropertyData(kAudioObjectSystemObject, &address, 0, NULL, &size, &device);
+    if (status != noErr)
+    {
+        params->result = osstatus_to_hresult(status);
+        return STATUS_SUCCESS;
+    }
+    if (device == kAudioObjectUnknown)
+    {
+        params->size = 0;
+        params->result = S_FALSE;
+        return STATUS_SUCCESS;
+    }
+
+    address.mSelector = kAudioDevicePropertyDeviceUID;
+    size = sizeof(uid);
+    status = AudioObjectGetPropertyData(device, &address, 0, NULL, &size, &uid);
+    if (status != noErr || !uid)
+    {
+        if (uid) CFRelease(uid);
+        params->result = status == noErr ? E_FAIL : osstatus_to_hresult(status);
+        return STATUS_SUCCESS;
+    }
+
+    capacity = params->size;
+    length = 0;
+    CFStringGetBytes(uid, CFRangeMake(0, CFStringGetLength(uid)), kCFStringEncodingUTF8,
+            0, false, NULL, 0, &length);
+    if (length < 0 || (SIZE_T)length >= UINT_MAX)
+    {
+        CFRelease(uid);
+        params->result = E_OUTOFMEMORY;
+        return STATUS_SUCCESS;
+    }
+    params->size = (UINT)length + 1;
+    if (!params->device || params->size > capacity)
+    {
+        CFRelease(uid);
+        params->result = HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
+        return STATUS_SUCCESS;
+    }
+    CFStringGetBytes(uid, CFRangeMake(0, CFStringGetLength(uid)), kCFStringEncodingUTF8,
+            0, false, (UInt8 *)params->device, params->size - 1, NULL);
+    params->device[params->size - 1] = 0;
+    CFRelease(uid);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
 
 static NTSTATUS unix_not_implemented(void *args)
 {
@@ -241,7 +466,7 @@ static NTSTATUS unix_get_endpoint_ids(void *args)
     UniChar *ptr;
 
     params->num = 0;
-    params->default_idx = 0;
+    params->default_idx = UINT_MAX;
 
     addr.mScope = kAudioObjectPropertyScopeGlobal;
     addr.mElement = kAudioObjectPropertyElementMain;
@@ -256,7 +481,8 @@ static NTSTATUS unix_get_endpoint_ids(void *args)
     sc = AudioObjectGetPropertyData(kAudioObjectSystemObject, &addr, 0, NULL, &size, &default_id);
     if(sc != noErr){
         WARN("Getting _DefaultInputDevice property failed: %x\n", (int)sc);
-        default_id = -1;
+        params->result = osstatus_to_hresult(sc);
+        return STATUS_SUCCESS;
     }
 
     addr.mSelector = kAudioHardwarePropertyDevices;
@@ -268,12 +494,20 @@ static NTSTATUS unix_get_endpoint_ids(void *args)
     }
 
     num_devices = devsize / sizeof(AudioDeviceID);
-    devices = malloc(devsize);
-    info = malloc(num_devices * sizeof(*info));
-    if(!devices || !info){
+    devices = devsize ? malloc(devsize) : NULL;
+    info = num_devices ? malloc(num_devices * sizeof(*info)) : NULL;
+    if((devsize && !devices) || (num_devices && !info)){
         free(info);
         free(devices);
         params->result = E_OUTOFMEMORY;
+        return STATUS_SUCCESS;
+    }
+
+    if (!devsize)
+    {
+        free(info);
+        free(devices);
+        params->result = S_OK;
         return STATUS_SUCCESS;
     }
 
@@ -1835,6 +2069,10 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
     unix_midi_in_message,
     unix_midi_notify_wait,
     unix_not_implemented,
+    unix_device_notifications_start,
+    unix_device_notifications_wait,
+    unix_device_notifications_stop,
+    unix_get_default_output,
 };
 
 C_ASSERT(ARRAYSIZE(__wine_unix_call_funcs) == funcs_count);
@@ -1879,6 +2117,25 @@ static NTSTATUS unix_wow64_get_endpoint_ids(void *args)
     params32->num = params.num;
     params32->default_idx = params.default_idx;
     return STATUS_SUCCESS;
+}
+
+static NTSTATUS unix_wow64_get_default_output(void *args)
+{
+    struct
+    {
+        PTR32 device;
+        UINT size;
+        HRESULT result;
+    } *params32 = args;
+    struct get_default_output_params params =
+    {
+        .device = ULongToPtr(params32->device),
+        .size = params32->size,
+    };
+    NTSTATUS status = unix_get_default_output(&params);
+    params32->size = params.size;
+    params32->result = params.result;
+    return status;
 }
 
 static NTSTATUS unix_wow64_create_stream(void *args)
@@ -2291,6 +2548,10 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
     unix_wow64_midi_in_message,
     unix_wow64_midi_notify_wait,
     unix_not_implemented,
+    unix_device_notifications_start,
+    unix_device_notifications_wait,
+    unix_device_notifications_stop,
+    unix_wow64_get_default_output,
 };
 
 C_ASSERT(ARRAYSIZE(__wine_unix_call_wow64_funcs) == funcs_count);

--- a/dlls/winecoreaudio.drv/coreaudio.c
+++ b/dlls/winecoreaudio.drv/coreaudio.c
@@ -480,7 +480,8 @@ static NTSTATUS unix_get_endpoint_ids(void *args)
     size = sizeof(default_id);
     sc = AudioObjectGetPropertyData(kAudioObjectSystemObject, &addr, 0, NULL, &size, &default_id);
     if(sc != noErr){
-        WARN("Getting _DefaultInputDevice property failed: %x\n", (int)sc);
+        WARN("Getting %s property failed: %x\n",
+                params->flow == eRender ? "_DefaultOutputDevice" : "_DefaultInputDevice", (int)sc);
         params->result = osstatus_to_hresult(sc);
         return STATUS_SUCCESS;
     }

--- a/dlls/wineoss.drv/oss.c
+++ b/dlls/wineoss.drv/oss.c
@@ -1674,6 +1674,10 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
     oss_midi_in_message,
     oss_midi_notify_wait,
     oss_aux_message,
+    oss_not_implemented,
+    oss_not_implemented,
+    oss_not_implemented,
+    oss_not_implemented,
 };
 
 C_ASSERT(ARRAYSIZE(__wine_unix_call_funcs) == funcs_count);
@@ -2170,6 +2174,10 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
     oss_wow64_midi_in_message,
     oss_wow64_midi_notify_wait,
     oss_wow64_aux_message,
+    oss_not_implemented,
+    oss_not_implemented,
+    oss_not_implemented,
+    oss_not_implemented,
 };
 
 C_ASSERT(ARRAYSIZE(__wine_unix_call_wow64_funcs) == funcs_count);

--- a/dlls/winepulse.drv/pulse.c
+++ b/dlls/winepulse.drv/pulse.c
@@ -2557,6 +2557,10 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
     pulse_not_implemented,
     pulse_not_implemented,
     pulse_not_implemented,
+    pulse_not_implemented,
+    pulse_not_implemented,
+    pulse_not_implemented,
+    pulse_not_implemented,
 };
 
 C_ASSERT(ARRAYSIZE(__wine_unix_call_funcs) == funcs_count);
@@ -3048,6 +3052,10 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
     pulse_is_started,
     pulse_wow64_get_prop_value,
     pulse_midi_get_driver,
+    pulse_not_implemented,
+    pulse_not_implemented,
+    pulse_not_implemented,
+    pulse_not_implemented,
     pulse_not_implemented,
     pulse_not_implemented,
     pulse_not_implemented,

--- a/dlls/winmm/waveform.c
+++ b/dlls/winmm/waveform.c
@@ -789,7 +789,7 @@ static HRESULT WINAPI notif_OnDefaultDeviceChanged(IMMNotificationClient *iface,
 
     TRACE("%u %u %s\n", flow, role, wine_dbgstr_w(device_id));
 
-    if(role != eConsole)
+    if(role != eConsole || !device_id)
         return S_OK;
 
     EnterCriticalSection(&g_devthread_lock);


### PR DESCRIPTION
Add CoreAudio listeners to keep Wine’s audio endpoints and default output synchronized with macOS.

  - Rescan endpoints when the device list changes.
  - Update the default output separately, rescanning only when necessary.
  - Preserve endpoint identity across disconnection and reconnection.
  - Reuse existing default-device notifications.
  - Prevent a WinMM crash when a default-device notification contains a null device ID.

Testing was completed on macOS using FFXIV on the TC servers, including repeated Bluetooth headset reconnections.